### PR TITLE
Fix field type checking

### DIFF
--- a/.github/workflows/ci-mssql.yml
+++ b/.github/workflows/ci-mssql.yml
@@ -24,7 +24,10 @@ jobs:
             extensions: pdo, pdo_sqlsrv
             mssql: 'server:2019-latest'
           - php: '8.1'
-            extensions: pdo, pdo_sqlsrv-5.10.0beta2
+            extensions: pdo, pdo_sqlsrv-5.11.0
+            mssql: 'server:2019-latest'
+          - php: '8.2'
+            extensions: pdo, pdo_sqlsrv-5.11.0
             mssql: 'server:2019-latest'
 
     services:

--- a/.github/workflows/ci-mysql.yml
+++ b/.github/workflows/ci-mysql.yml
@@ -22,6 +22,7 @@ jobs:
         php-version:
           - "8.0"
           - "8.1"
+          - "8.2"
 
         mysql-version:
           - "5.7"

--- a/.github/workflows/ci-pgsql.yml
+++ b/.github/workflows/ci-pgsql.yml
@@ -21,6 +21,7 @@ jobs:
         php-version:
           - "8.0"
           - "8.1"
+          - "8.2"
 
         pgsql-version:
           - "10"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,6 +16,7 @@ jobs:
         php-version:
           - "8.0"
           - "8.1"
+          - "8.2"
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -72,6 +73,7 @@ jobs:
         php-version:
           - "8.0"
           - "8.1"
+          - "8.2"
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -1,16 +1,47 @@
-on:
-    pull_request:
-    push:
-        branches:
-            - '*.*'
-
 name: static analysis
 
+on: [push, pull_request]
+
 jobs:
-    psalm:
-        uses: spiral/gh-actions/.github/workflows/psalm.yml@master
-        with:
-            os: >-
-                ['ubuntu-latest']
-            php: >-
-                ['8.1']
+    mutation:
+        name: PHP ${{ matrix.php }}-${{ matrix.os }}
+
+        runs-on: ${{ matrix.os }}
+
+        strategy:
+            matrix:
+                os:
+                    - ubuntu-latest
+
+                php:
+                    - "8.0"
+
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v2.3.4
+
+            - name: Install PHP
+              uses: shivammathur/setup-php@v2
+              with:
+                  php-version: "${{ matrix.php }}"
+                  tools: composer:v2, cs2pr
+                  coverage: none
+
+            - name: Determine composer cache directory
+              run: echo "COMPOSER_CACHE_DIR=$(composer config cache-dir)" >> $GITHUB_ENV
+
+            - name: Cache dependencies installed with composer
+              uses: actions/cache@v2
+              with:
+                  path: ${{ env.COMPOSER_CACHE_DIR }}
+                  key: php${{ matrix.php }}-composer-${{ hashFiles('**/composer.json') }}
+                  restore-keys: |
+                      php${{ matrix.php }}-composer-
+            - name: Update composer
+              run: composer self-update
+
+            - name: Install dependencies with composer
+              run: composer update --prefer-dist --no-interaction --no-progress --optimize-autoloader --ansi
+
+            - name: Static analysis
+              run: vendor/bin/psalm --shepherd --stats --output-format=checkstyle

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -13,4 +13,4 @@ jobs:
             os: >-
                 ['ubuntu-latest']
             php: >-
-                ['8.2']
+                ['8.1']

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -1,47 +1,16 @@
+on:
+    pull_request:
+    push:
+        branches:
+            - '*.*'
+
 name: static analysis
 
-on: [push, pull_request]
-
 jobs:
-    mutation:
-        name: PHP ${{ matrix.php }}-${{ matrix.os }}
-
-        runs-on: ${{ matrix.os }}
-
-        strategy:
-            matrix:
-                os:
-                    - ubuntu-latest
-
-                php:
-                    - "8.0"
-
-        steps:
-            - name: Checkout
-              uses: actions/checkout@v2.3.4
-
-            - name: Install PHP
-              uses: shivammathur/setup-php@v2
-              with:
-                  php-version: "${{ matrix.php }}"
-                  tools: composer:v2, cs2pr
-                  coverage: none
-
-            - name: Determine composer cache directory
-              run: echo "COMPOSER_CACHE_DIR=$(composer config cache-dir)" >> $GITHUB_ENV
-
-            - name: Cache dependencies installed with composer
-              uses: actions/cache@v2
-              with:
-                  path: ${{ env.COMPOSER_CACHE_DIR }}
-                  key: php${{ matrix.php }}-composer-${{ hashFiles('**/composer.json') }}
-                  restore-keys: |
-                      php${{ matrix.php }}-composer-
-            - name: Update composer
-              run: composer self-update
-
-            - name: Install dependencies with composer
-              run: composer update --prefer-dist --no-interaction --no-progress --optimize-autoloader --ansi
-
-            - name: Static analysis
-              run: vendor/bin/psalm --shepherd --stats --output-format=checkstyle
+    psalm:
+        uses: spiral/gh-actions/.github/workflows/psalm.yml@master
+        with:
+            os: >-
+                ['ubuntu-latest']
+            php: >-
+                ['8.2']

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -1,47 +1,16 @@
+on:
+    pull_request:
+    push:
+        branches:
+            - '*.*'
+
 name: static analysis
 
-on: [push, pull_request]
-
 jobs:
-    mutation:
-        name: PHP ${{ matrix.php }}-${{ matrix.os }}
-
-        runs-on: ${{ matrix.os }}
-
-        strategy:
-            matrix:
-                os:
-                    - ubuntu-latest
-
-                php:
-                    - "8.0"
-
-        steps:
-            - name: Checkout
-              uses: actions/checkout@v2.3.4
-
-            - name: Install PHP
-              uses: shivammathur/setup-php@v2
-              with:
-                  php-version: "${{ matrix.php }}"
-                  tools: composer:v2, cs2pr
-                  coverage: none
-
-            - name: Determine composer cache directory
-              run: echo "COMPOSER_CACHE_DIR=$(composer config cache-dir)" >> $GITHUB_ENV
-
-            - name: Cache dependencies installed with composer
-              uses: actions/cache@v2
-              with:
-                  path: ${{ env.COMPOSER_CACHE_DIR }}
-                  key: php${{ matrix.php }}-composer-${{ hashFiles('**/composer.json') }}
-                  restore-keys: |
-                      php${{ matrix.php }}-composer-
-            - name: Update composer
-              run: composer self-update
-
-            - name: Install dependencies with composer
-              run: composer update --prefer-dist --no-interaction --no-progress --optimize-autoloader --ansi
-
-            - name: Static analysis
-              run: vendor/bin/psalm --shepherd --stats --output-format=checkstyle
+    psalm:
+        uses: spiral/gh-actions/.github/workflows/psalm.yml@master
+        with:
+            os: >-
+                ['ubuntu-latest']
+            php: >-
+                ['8.1']

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,6 @@
 {
     "name": "cycle/entity-behavior",
+    "description": "Provides a collection of attributes that add behaviors to Cycle ORM entities",
     "type": "library",
     "require": {
         "php": ">=8.0",

--- a/composer.json
+++ b/composer.json
@@ -11,10 +11,10 @@
     },
     "require-dev": {
         "cycle/annotated": "^3.0",
-        "ramsey/uuid": "^4.0",
+        "ramsey/uuid": "^4.5",
         "phpunit/phpunit": "^9.5",
-        "spiral/tokenizer": "^2.8",
-        "vimeo/psalm": "^4.13"
+        "spiral/tokenizer": "^2.8 || ^3.0",
+        "vimeo/psalm": "^5.11"
     },
     "license": "MIT",
     "autoload": {

--- a/psalm.xml
+++ b/psalm.xml
@@ -4,6 +4,8 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns="https://getpsalm.org/schema/config"
     xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
+    findUnusedBaselineEntry="true"
+    findUnusedCode="false"
 >
     <projectFiles>
         <directory name="src" />

--- a/src/Schema/RegistryModifier.php
+++ b/src/Schema/RegistryModifier.php
@@ -19,6 +19,18 @@ use Cycle\Schema\Registry;
  */
 class RegistryModifier
 {
+    protected const DEFINITION = '/(?P<type>[a-z]+)(?: *\((?P<options>[^\)]+)\))?/i';
+    protected const INTEGER_TYPES = [
+        'int',
+        'smallint',
+        'tinyint',
+        'bigint',
+        'integer',
+        'tinyInteger',
+        'smallInteger',
+        'bigInteger',
+    ];
+    protected const DATETIME_TYPES = ['datetime', 'datetime2'];
     protected const INT_COLUMN = AbstractColumn::INT;
     protected const STRING_COLUMN = AbstractColumn::STRING;
     protected const DATETIME_COLUMN = 'datetime';
@@ -38,7 +50,7 @@ class RegistryModifier
     public function addDatetimeColumn(string $columnName, string $fieldName): AbstractColumn
     {
         if ($this->fields->has($fieldName)) {
-            if (!$this->isType(self::DATETIME_COLUMN, $fieldName, $columnName)) {
+            if (!static::isDatetimeType($this->fields->get($fieldName)->getType())) {
                 throw new BehaviorCompilationException(sprintf('Field %s must be of type datetime.', $fieldName));
             }
             $this->validateColumnName($fieldName, $columnName);
@@ -57,7 +69,7 @@ class RegistryModifier
     public function addIntegerColumn(string $columnName, string $fieldName): AbstractColumn
     {
         if ($this->fields->has($fieldName)) {
-            if (!$this->isType(self::INT_COLUMN, $fieldName, $columnName)) {
+            if (!static::isIntegerType($this->fields->get($fieldName)->getType())) {
                 throw new BehaviorCompilationException(sprintf('Field %s must be of type integer.', $fieldName));
             }
             $this->validateColumnName($fieldName, $columnName);
@@ -73,7 +85,7 @@ class RegistryModifier
     public function addStringColumn(string $columnName, string $fieldName): AbstractColumn
     {
         if ($this->fields->has($fieldName)) {
-            if (!$this->isType(self::STRING_COLUMN, $fieldName, $columnName)) {
+            if (!static::isStringType($this->fields->get($fieldName)->getType())) {
                 throw new BehaviorCompilationException(sprintf('Field %s must be of type string.', $fieldName));
             }
             $this->validateColumnName($fieldName, $columnName);
@@ -92,7 +104,7 @@ class RegistryModifier
     public function addUuidColumn(string $columnName, string $fieldName): AbstractColumn
     {
         if ($this->fields->has($fieldName)) {
-            if (!$this->isType(self::UUID_COLUMN, $fieldName, $columnName)) {
+            if (!static::isUuidType($this->fields->get($fieldName)->getType())) {
                 throw new BehaviorCompilationException(sprintf('Field %s must be of type uuid.', $fieldName));
             }
             $this->validateColumnName($fieldName, $columnName);
@@ -156,6 +168,9 @@ class RegistryModifier
         }
     }
 
+    /**
+     * @deprecated since v1.2
+     */
     protected function isType(string $type, string $fieldName, string $columnName): bool
     {
         if ($type === self::DATETIME_COLUMN) {
@@ -175,5 +190,33 @@ class RegistryModifier
         }
 
         return $this->table->column($columnName)->getType() === $type;
+    }
+
+    public static function isIntegerType(string $type): bool
+    {
+        \preg_match(self::DEFINITION, $type, $matches);
+
+        return \in_array($matches['type'], self::INTEGER_TYPES, true);
+    }
+
+    public static function isDatetimeType(string $type): bool
+    {
+        \preg_match(self::DEFINITION, $type, $matches);
+
+        return \in_array($matches['type'], self::DATETIME_TYPES, true);
+    }
+
+    public static function isStringType(string $type): bool
+    {
+        \preg_match(self::DEFINITION, $type, $matches);
+
+        return $matches['type'] === 'string';
+    }
+
+    public static function isUuidType(string $type): bool
+    {
+        \preg_match(self::DEFINITION, $type, $matches);
+
+        return $matches['type'] === 'uuid';
     }
 }

--- a/tests/Behavior/Fixtures/OptimisticLock/WithAllParameters.php
+++ b/tests/Behavior/Fixtures/OptimisticLock/WithAllParameters.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\ORM\Entity\Behavior\Tests\Fixtures\OptimisticLock;
+
+use Cycle\Annotated\Annotation\Column;
+use Cycle\Annotated\Annotation\Entity;
+use Cycle\ORM\Entity\Behavior\OptimisticLock;
+
+#[Entity]
+#[OptimisticLock(
+    field: 'revision',
+    column: 'revision_field',
+    rule: OptimisticLock::RULE_INCREMENT
+)]
+final class WithAllParameters
+{
+    #[Column(type: 'primary')]
+    public int $id;
+
+    #[Column(type: 'integer', name: 'revision_field')]
+    public int $revision;
+}

--- a/tests/Behavior/Functional/Driver/Common/BaseTest.php
+++ b/tests/Behavior/Functional/Driver/Common/BaseTest.php
@@ -20,6 +20,7 @@ abstract class BaseTest extends TestCase
 
     public static array $config;
     protected ?DatabaseManager $dbal = null;
+    protected ?DriverInterface $driver = null;
     private static array $driverCache = [];
 
     public function setUp(): void

--- a/tests/Behavior/Functional/Driver/Common/OptimisticLock/OptimisticLockTest.php
+++ b/tests/Behavior/Functional/Driver/Common/OptimisticLock/OptimisticLockTest.php
@@ -10,6 +10,7 @@ use Cycle\ORM\Entity\Behavior\Tests\Fixtures\OptimisticLock\News;
 use Cycle\ORM\Entity\Behavior\Tests\Fixtures\OptimisticLock\Page;
 use Cycle\ORM\Entity\Behavior\Tests\Fixtures\OptimisticLock\Post;
 use Cycle\ORM\Entity\Behavior\Tests\Fixtures\OptimisticLock\Product;
+use Cycle\ORM\Entity\Behavior\Tests\Fixtures\OptimisticLock\WithAllParameters;
 use Cycle\ORM\Entity\Behavior\Tests\Functional\Driver\Common\BaseSchemaTest;
 use Spiral\Tokenizer\Config\TokenizerConfig;
 use Spiral\Tokenizer\Tokenizer;
@@ -56,6 +57,18 @@ abstract class OptimisticLockTest extends BaseSchemaTest
     public function testExistColumn(): void
     {
         $fields = $this->registry->getEntity(Product::class)->getFields();
+
+        $this->assertTrue($fields->has('revision'));
+        $this->assertTrue($fields->hasColumn('revision_field'));
+        $this->assertSame('integer', $fields->get('revision')->getType());
+
+        // not added new columns
+        $this->assertSame(2, $fields->count());
+    }
+
+    public function testExistColumnAndAllOptimisticLockParameters(): void
+    {
+        $fields = $this->registry->getEntity(WithAllParameters::class)->getFields();
 
         $this->assertTrue($fields->has('revision'));
         $this->assertTrue($fields->hasColumn('revision_field'));

--- a/tests/Behavior/Functional/Driver/Common/Schema/RegistryModifierTest.php
+++ b/tests/Behavior/Functional/Driver/Common/Schema/RegistryModifierTest.php
@@ -18,6 +18,7 @@ abstract class RegistryModifierTest extends BaseTest
     private const ROLE_TEST = 'test';
 
     protected RegistryModifier $modifier;
+    protected Registry $registry;
 
     public function setUp(): void
     {

--- a/tests/Behavior/Unit/Schema/RegistryModifierTest.php
+++ b/tests/Behavior/Unit/Schema/RegistryModifierTest.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\ORM\Entity\Behavior\Tests\Unit\Schema;
+
+use Cycle\ORM\Entity\Behavior\Schema\RegistryModifier;
+use PHPUnit\Framework\TestCase;
+
+final class RegistryModifierTest extends TestCase
+{
+    /**
+     * @dataProvider integerDataProvider
+     */
+    public function testIsIntegerTypeTrue(mixed $type): void
+    {
+        $this->assertTrue(RegistryModifier::isIntegerType($type));
+    }
+
+    /**
+     * @dataProvider datetimeDataProvider
+     * @dataProvider stringDataProvider
+     * @dataProvider invalidDataProvider
+     */
+    public function testIsIntegerTypeFalse(mixed $type): void
+    {
+        $this->assertFalse(RegistryModifier::isIntegerType($type));
+    }
+
+    /**
+     * @dataProvider datetimeDataProvider
+     */
+    public function testIsDatetimeTypeTrue(mixed $type): void
+    {
+        $this->assertTrue(RegistryModifier::isDatetimeType($type));
+    }
+
+    /**
+     * @dataProvider integerDataProvider
+     * @dataProvider stringDataProvider
+     * @dataProvider invalidDataProvider
+     */
+    public function testIsDatetimeTypeFalse(mixed $type): void
+    {
+        $this->assertFalse(RegistryModifier::isDatetimeType($type));
+    }
+
+    /**
+     * @dataProvider stringDataProvider
+     */
+    public function testIsStringTypeTrue(mixed $type): void
+    {
+        $this->assertTrue(RegistryModifier::isStringType($type));
+    }
+
+    /**
+     * @dataProvider integerDataProvider
+     * @dataProvider datetimeDataProvider
+     * @dataProvider invalidDataProvider
+     */
+    public function testIsStringTypeFalse(mixed $type): void
+    {
+        $this->assertFalse(RegistryModifier::isStringType($type));
+    }
+
+    public function testIsUuidTypeTrue(): void
+    {
+        $this->assertTrue(RegistryModifier::isUuidType('uuid'));
+    }
+
+    /**
+     * @dataProvider integerDataProvider
+     * @dataProvider datetimeDataProvider
+     * @dataProvider invalidDataProvider
+     * @dataProvider stringDataProvider
+     */
+    public function testIsUuidTypeFalse(mixed $type): void
+    {
+        $this->assertFalse(RegistryModifier::isUuidType($type));
+    }
+
+    public static function integerDataProvider(): \Traversable
+    {
+        yield ['int'];
+        yield ['smallint'];
+        yield ['tinyint'];
+        yield ['bigint'];
+        yield ['integer'];
+        yield ['tinyInteger'];
+        yield ['smallInteger'];
+        yield ['bigInteger'];
+        yield ['integer(4)'];
+    }
+
+    public static function datetimeDataProvider(): \Traversable
+    {
+        yield ['datetime'];
+        yield ['datetime2'];
+        yield ['datetime2(7)'];
+    }
+
+    public static function stringDataProvider(): \Traversable
+    {
+        yield ['string'];
+        yield ['string(32)'];
+    }
+
+    public static function invalidDataProvider(): \Traversable
+    {
+        yield ['text'];
+        yield ['json'];
+        yield ['foo'];
+        yield ['bar(32)'];
+    }
+}


### PR DESCRIPTION
Can't use **->column($this->column)** here:
https://github.com/cycle/entity-behavior/blob/1.x/src/OptimisticLock.php#L126

The column has not yet been created, and this method creates it with the specified name, without a type. We can only check the column type using the type in the `Cycle\Schema\Definition\Field`.

#### Other changes

1) Added PHP 8.2 tests
2) Updated Psalm to v5.11