### PR TITLE
Add support for generated fields

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,3 @@
+# These are supported funding model platforms
+
+github: cycle

--- a/.github/workflows/ci-mssql.yml
+++ b/.github/workflows/ci-mssql.yml
@@ -26,10 +26,13 @@ jobs:
             extensions: pdo, pdo_sqlsrv
             mssql: 'server:2019-latest'
           - php: '8.1'
-            extensions: pdo, pdo_sqlsrv-5.11.0
+            extensions: pdo, pdo_sqlsrv
             mssql: 'server:2019-latest'
           - php: '8.2'
-            extensions: pdo, pdo_sqlsrv-5.11.0
+            extensions: pdo, pdo_sqlsrv
+            mssql: 'server:2019-latest'
+          - php: '8.3'
+            extensions: pdo, pdo_sqlsrv
             mssql: 'server:2019-latest'
 
     services:
@@ -70,11 +73,11 @@ jobs:
         run: composer self-update
 
       - name: Install dependencies with composer
-        if: matrix.php != '8.2'
+        if: matrix.php != '8.4'
         run: composer update --prefer-dist --no-interaction --no-progress --optimize-autoloader --ansi
 
-      - name: Install dependencies with composer php 8.2
-        if: matrix.php == '8.2'
+      - name: Install dependencies with composer php 8.4
+        if: matrix.php == '8.4'
         run: composer update --ignore-platform-reqs --prefer-dist --no-interaction --no-progress --optimize-autoloader --ansi
 
       - name: Run tests with phpunit without coverage

--- a/.github/workflows/ci-mysql.yml
+++ b/.github/workflows/ci-mysql.yml
@@ -25,6 +25,7 @@ jobs:
           - "8.0"
           - "8.1"
           - "8.2"
+          - "8.3"
 
         mysql-version:
           - "5.7"
@@ -81,11 +82,11 @@ jobs:
             php${{ matrix.php-version }}-composer-${{ matrix.dependencies }}-
 
       - name: Install dependencies with composer
-        if: matrix.php-version != '8.2'
+        if: matrix.php-version != '8.4'
         run: composer update --prefer-dist --no-interaction --no-progress --optimize-autoloader --ansi
 
-      - name: Install dependencies with composer php 8.2
-        if: matrix.php-version == '8.2'
+      - name: Install dependencies with composer php 8.4
+        if: matrix.php-version == '8.4'
         run: composer update --ignore-platform-reqs --prefer-dist --no-interaction --no-progress --optimize-autoloader --ansi
 
       - name: Run mysql tests with phpunit

--- a/.github/workflows/ci-pgsql.yml
+++ b/.github/workflows/ci-pgsql.yml
@@ -24,6 +24,7 @@ jobs:
           - "8.0"
           - "8.1"
           - "8.2"
+          - "8.3"
 
         pgsql-version:
           - "10"
@@ -82,11 +83,11 @@ jobs:
             php${{ matrix.php-version }}-composer-${{ matrix.dependencies }}-
 
       - name: Install dependencies with composer
-        if: matrix.php-version != '8.2'
+        if: matrix.php-version != '8.4'
         run: composer update --prefer-dist --no-interaction --no-progress --optimize-autoloader --ansi
 
-      - name: Install dependencies with composer php 8.2
-        if: matrix.php-version == '8.2'
+      - name: Install dependencies with composer php 8.4
+        if: matrix.php-version == '8.4'
         run: composer update --ignore-platform-reqs --prefer-dist --no-interaction --no-progress --optimize-autoloader --ansi
 
       - name: Run pgsql tests with phpunit

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,6 +21,7 @@ jobs:
           - "8.0"
           - "8.1"
           - "8.2"
+          - "8.3"
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -46,10 +47,10 @@ jobs:
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
           restore-keys: ${{ runner.os }}-composer-
       - name: Install dependencies with composer
-        if: matrix.php-version != '8.2'
+        if: matrix.php-version != '8.4'
         run: composer update --prefer-dist --no-interaction --no-progress --optimize-autoloader --ansi
-      - name: Install dependencies with composer php 8.2
-        if: matrix.php-version == '8.2'
+      - name: Install dependencies with composer php 8.4
+        if: matrix.php-version == '8.4'
         run: composer update --ignore-platform-reqs --prefer-dist --no-interaction --no-progress --optimize-autoloader --ansi
       - name: Execute Tests
         run: |
@@ -78,6 +79,7 @@ jobs:
           - "8.0"
           - "8.1"
           - "8.2"
+          - "8.3"
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -99,11 +101,11 @@ jobs:
           restore-keys: ${{ runner.os }}-composer-
 
       - name: Install dependencies with composer
-        if: matrix.php-version != '8.1'
+        if: matrix.php-version != '8.4'
         run: composer update --prefer-dist --no-interaction --no-progress --optimize-autoloader --ansi
 
-      - name: Install dependencies with composer php 8.1
-        if: matrix.php-version == '8.1'
+      - name: Install dependencies with composer php 8.4
+        if: matrix.php-version == '8.4'
         run: composer update --ignore-platform-reqs --prefer-dist --no-interaction --no-progress --optimize-autoloader --ansi
 
       - name: Execute Tests

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -12,5 +12,3 @@ jobs:
         with:
             os: >-
                 ['ubuntu-latest']
-            php: >-
-                ['8.1']

--- a/composer.json
+++ b/composer.json
@@ -2,6 +2,38 @@
     "name": "cycle/entity-behavior",
     "description": "Provides a collection of attributes that add behaviors to Cycle ORM entities",
     "type": "library",
+    "license": "MIT",
+    "homepage": "https://cycle-orm.dev",
+    "support": {
+        "issues": "https://github.com/cycle/entity-behavior/issues",
+        "source": "https://github.com/cycle/entity-behavior",
+        "docs": "https://cycle-orm.dev/docs",
+        "chat": "https://discord.gg/spiralphp"
+    },
+    "authors": [
+        {
+            "name": "Anton Titov (wolfy-j)",
+            "email": "wolfy-j@spiralscout.com"
+        },
+        {
+            "name": "Aleksei Gagarin (roxblnfk)",
+            "email": "alexey.gagarin@spiralscout.com"
+        },
+        {
+            "name": "Pavel Butchnev (butschster)",
+            "email": "pavel.buchnev@spiralscout.com"
+        },
+        {
+            "name": "Maksim Smakouz (msmakouz)",
+            "email": "maksim.smakouz@spiralscout.com"
+        }
+    ],
+    "funding": [
+        {
+            "type": "github",
+            "url": "https://github.com/sponsors/cycle"
+        }
+    ],
     "require": {
         "php": ">=8.0",
         "psr/event-dispatcher": "^1",
@@ -17,7 +49,6 @@
         "spiral/tokenizer": "^2.8 || ^3.0",
         "vimeo/psalm": "^5.11"
     },
-    "license": "MIT",
     "autoload": {
         "psr-4": {
             "Cycle\\ORM\\Entity\\Behavior\\": "src/"

--- a/composer.json
+++ b/composer.json
@@ -5,8 +5,8 @@
     "require": {
         "php": ">=8.0",
         "psr/event-dispatcher": "^1",
-        "cycle/orm": "^2.0",
-        "cycle/schema-builder": "^2.5",
+        "cycle/orm": "^2.7",
+        "cycle/schema-builder": "^2.8",
         "psr/container": "^1.0|^2.0",
         "yiisoft/injector": "^1.0"
     },

--- a/src/CreatedAt.php
+++ b/src/CreatedAt.php
@@ -8,6 +8,7 @@ use Cycle\Database\Schema\AbstractColumn;
 use Cycle\ORM\Entity\Behavior\Schema\BaseModifier;
 use Cycle\ORM\Entity\Behavior\Schema\RegistryModifier;
 use Cycle\ORM\Entity\Behavior\Listener\CreatedAt as Listener;
+use Cycle\ORM\SchemaInterface;
 use Cycle\Schema\Registry;
 use Doctrine\Common\Annotations\Annotation\Attribute;
 use Doctrine\Common\Annotations\Annotation\Attributes;
@@ -63,7 +64,7 @@ final class CreatedAt extends BaseModifier
         $this->column = $modifier->findColumnName($this->field, $this->column);
 
         if ($this->column !== null) {
-            $modifier->addDatetimeColumn($this->column, $this->field)
+            $modifier->addDatetimeColumn($this->column, $this->field, SchemaInterface::GENERATED_PHP_INSERT)
                 ->nullable(false)
                 ->defaultValue(AbstractColumn::DATETIME_NOW);
         }
@@ -75,7 +76,7 @@ final class CreatedAt extends BaseModifier
 
         $this->column = $modifier->findColumnName($this->field, $this->column) ?? $this->field;
 
-        $modifier->addDatetimeColumn($this->column, $this->field)
+        $modifier->addDatetimeColumn($this->column, $this->field, SchemaInterface::GENERATED_PHP_INSERT)
             ->nullable(false)
             ->defaultValue(AbstractColumn::DATETIME_NOW);
     }

--- a/src/CreatedAt.php
+++ b/src/CreatedAt.php
@@ -8,7 +8,7 @@ use Cycle\Database\Schema\AbstractColumn;
 use Cycle\ORM\Entity\Behavior\Schema\BaseModifier;
 use Cycle\ORM\Entity\Behavior\Schema\RegistryModifier;
 use Cycle\ORM\Entity\Behavior\Listener\CreatedAt as Listener;
-use Cycle\ORM\SchemaInterface;
+use Cycle\ORM\Schema\GeneratedField;
 use Cycle\Schema\Registry;
 use Doctrine\Common\Annotations\Annotation\Attribute;
 use Doctrine\Common\Annotations\Annotation\Attributes;
@@ -64,7 +64,7 @@ final class CreatedAt extends BaseModifier
         $this->column = $modifier->findColumnName($this->field, $this->column);
 
         if ($this->column !== null) {
-            $modifier->addDatetimeColumn($this->column, $this->field, SchemaInterface::GENERATED_PHP_INSERT)
+            $modifier->addDatetimeColumn($this->column, $this->field, GeneratedField::BEFORE_INSERT)
                 ->nullable(false)
                 ->defaultValue(AbstractColumn::DATETIME_NOW);
         }
@@ -76,7 +76,7 @@ final class CreatedAt extends BaseModifier
 
         $this->column = $modifier->findColumnName($this->field, $this->column) ?? $this->field;
 
-        $modifier->addDatetimeColumn($this->column, $this->field, SchemaInterface::GENERATED_PHP_INSERT)
+        $modifier->addDatetimeColumn($this->column, $this->field, GeneratedField::BEFORE_INSERT)
             ->nullable(false)
             ->defaultValue(AbstractColumn::DATETIME_NOW);
     }

--- a/src/OptimisticLock.php
+++ b/src/OptimisticLock.php
@@ -8,6 +8,7 @@ use Cycle\ORM\Entity\Behavior\Schema\BaseModifier;
 use Cycle\ORM\Entity\Behavior\Schema\RegistryModifier;
 use Cycle\ORM\Entity\Behavior\Exception\BehaviorCompilationException;
 use Cycle\ORM\Entity\Behavior\Listener\OptimisticLock as Listener;
+use Cycle\ORM\SchemaInterface;
 use Cycle\Schema\Definition\Field;
 use Cycle\Schema\Registry;
 use Doctrine\Common\Annotations\Annotation\Enum;
@@ -132,18 +133,32 @@ final class OptimisticLock extends BaseModifier
 
         switch ($this->rule) {
             case self::RULE_INCREMENT:
-                $modifier->addIntegerColumn($this->column, $this->field)
+                $modifier
+                    ->addIntegerColumn(
+                        $this->column,
+                        $this->field,
+                        SchemaInterface::GENERATED_PHP_INSERT | SchemaInterface::GENERATED_PHP_UPDATE
+                    )
                     ->nullable(false)
                     ->defaultValue(self::DEFAULT_INT_VERSION);
                 break;
             case self::RULE_RAND_STR:
             case self::RULE_MICROTIME:
-                $modifier->addStringColumn($this->column, $this->field)
+                $modifier
+                    ->addStringColumn(
+                        $this->column,
+                        $this->field,
+                        SchemaInterface::GENERATED_PHP_INSERT | SchemaInterface::GENERATED_PHP_UPDATE
+                    )
                     ->nullable(false)
                     ->string(self::STRING_COLUMN_LENGTH);
                 break;
             case self::RULE_DATETIME:
-                $modifier->addDatetimeColumn($this->column, $this->field);
+                $modifier->addDatetimeColumn(
+                    $this->column,
+                    $this->field,
+                    SchemaInterface::GENERATED_PHP_INSERT | SchemaInterface::GENERATED_PHP_UPDATE
+                );
                 break;
             default:
                 throw new BehaviorCompilationException(

--- a/src/OptimisticLock.php
+++ b/src/OptimisticLock.php
@@ -8,7 +8,7 @@ use Cycle\ORM\Entity\Behavior\Schema\BaseModifier;
 use Cycle\ORM\Entity\Behavior\Schema\RegistryModifier;
 use Cycle\ORM\Entity\Behavior\Exception\BehaviorCompilationException;
 use Cycle\ORM\Entity\Behavior\Listener\OptimisticLock as Listener;
-use Cycle\ORM\SchemaInterface;
+use Cycle\ORM\Schema\GeneratedField;
 use Cycle\Schema\Definition\Field;
 use Cycle\Schema\Registry;
 use Doctrine\Common\Annotations\Annotation\Enum;
@@ -137,7 +137,7 @@ final class OptimisticLock extends BaseModifier
                     ->addIntegerColumn(
                         $this->column,
                         $this->field,
-                        SchemaInterface::GENERATED_PHP_INSERT | SchemaInterface::GENERATED_PHP_UPDATE
+                        GeneratedField::BEFORE_INSERT | GeneratedField::BEFORE_UPDATE
                     )
                     ->nullable(false)
                     ->defaultValue(self::DEFAULT_INT_VERSION);
@@ -148,7 +148,7 @@ final class OptimisticLock extends BaseModifier
                     ->addStringColumn(
                         $this->column,
                         $this->field,
-                        SchemaInterface::GENERATED_PHP_INSERT | SchemaInterface::GENERATED_PHP_UPDATE
+                        GeneratedField::BEFORE_INSERT | GeneratedField::BEFORE_UPDATE
                     )
                     ->nullable(false)
                     ->string(self::STRING_COLUMN_LENGTH);
@@ -157,7 +157,7 @@ final class OptimisticLock extends BaseModifier
                 $modifier->addDatetimeColumn(
                     $this->column,
                     $this->field,
-                    SchemaInterface::GENERATED_PHP_INSERT | SchemaInterface::GENERATED_PHP_UPDATE
+                    GeneratedField::BEFORE_INSERT | GeneratedField::BEFORE_UPDATE
                 );
                 break;
             default:

--- a/src/Schema/RegistryModifier.php
+++ b/src/Schema/RegistryModifier.php
@@ -51,53 +51,64 @@ class RegistryModifier
         $this->defaults = $registry->getDefaults();
     }
 
-    public function addDatetimeColumn(string $columnName, string $fieldName): AbstractColumn
+    public function addDatetimeColumn(string $columnName, string $fieldName, int|null $generated = null): AbstractColumn
     {
         if ($this->fields->has($fieldName)) {
             if (!static::isDatetimeType($this->fields->get($fieldName)->getType())) {
                 throw new BehaviorCompilationException(sprintf('Field %s must be of type datetime.', $fieldName));
             }
             $this->validateColumnName($fieldName, $columnName);
+            $this->fields->get($fieldName)->setGenerated($generated);
 
             return $this->table->column($columnName);
         }
 
-        $this->fields->set(
-            $fieldName,
-            (new Field())->setColumn($columnName)->setType('datetime')->setTypecast('datetime')
-        );
+        $field = (new Field())
+            ->setColumn($columnName)
+            ->setType('datetime')
+            ->setTypecast('datetime')
+            ->setGenerated($generated);
+        $this->fields->set($fieldName, $field);
 
         return $this->table->column($columnName)->type(self::DATETIME_COLUMN);
     }
 
-    public function addIntegerColumn(string $columnName, string $fieldName): AbstractColumn
+    public function addIntegerColumn(string $columnName, string $fieldName, int|null $generated = null): AbstractColumn
     {
         if ($this->fields->has($fieldName)) {
             if (!static::isIntegerType($this->fields->get($fieldName)->getType())) {
                 throw new BehaviorCompilationException(sprintf('Field %s must be of type integer.', $fieldName));
             }
             $this->validateColumnName($fieldName, $columnName);
+            $this->fields->get($fieldName)->setGenerated($generated);
 
             return $this->table->column($columnName);
         }
 
-        $this->fields->set($fieldName, (new Field())->setColumn($columnName)->setType('integer')->setTypecast('int'));
+        $field = (new Field())
+            ->setColumn($columnName)
+            ->setType('integer')
+            ->setTypecast('int')
+            ->setGenerated($generated);
+        $this->fields->set($fieldName, $field);
 
         return $this->table->column($columnName)->type(self::INT_COLUMN);
     }
 
-    public function addStringColumn(string $columnName, string $fieldName): AbstractColumn
+    public function addStringColumn(string $columnName, string $fieldName, int|null $generated = null): AbstractColumn
     {
         if ($this->fields->has($fieldName)) {
             if (!static::isStringType($this->fields->get($fieldName)->getType())) {
                 throw new BehaviorCompilationException(sprintf('Field %s must be of type string.', $fieldName));
             }
             $this->validateColumnName($fieldName, $columnName);
+            $this->fields->get($fieldName)->setGenerated($generated);
 
             return $this->table->column($columnName);
         }
 
-        $this->fields->set($fieldName, (new Field())->setColumn($columnName)->setType('string'));
+        $field = (new Field())->setColumn($columnName)->setType('string')->setGenerated($generated);
+        $this->fields->set($fieldName, $field);
 
         return $this->table->column($columnName)->type(self::STRING_COLUMN);
     }
@@ -105,18 +116,20 @@ class RegistryModifier
     /**
      * @throws BehaviorCompilationException
      */
-    public function addUuidColumn(string $columnName, string $fieldName): AbstractColumn
+    public function addUuidColumn(string $columnName, string $fieldName, int|null $generated = null): AbstractColumn
     {
         if ($this->fields->has($fieldName)) {
             if (!static::isUuidType($this->fields->get($fieldName)->getType())) {
                 throw new BehaviorCompilationException(sprintf('Field %s must be of type uuid.', $fieldName));
             }
             $this->validateColumnName($fieldName, $columnName);
+            $this->fields->get($fieldName)->setGenerated($generated);
 
             return $this->table->column($columnName);
         }
 
-        $this->fields->set($fieldName, (new Field())->setColumn($columnName)->setType('uuid'));
+        $field = (new Field())->setColumn($columnName)->setType('uuid')->setGenerated($generated);
+        $this->fields->set($fieldName, $field);
 
         return $this->table->column($columnName)->type(self::UUID_COLUMN);
     }

--- a/src/SoftDelete.php
+++ b/src/SoftDelete.php
@@ -7,6 +7,7 @@ namespace Cycle\ORM\Entity\Behavior;
 use Cycle\ORM\Entity\Behavior\Schema\BaseModifier;
 use Cycle\ORM\Entity\Behavior\Schema\RegistryModifier;
 use Cycle\ORM\Entity\Behavior\Listener\SoftDelete as Listener;
+use Cycle\ORM\SchemaInterface;
 use Cycle\Schema\Registry;
 use Doctrine\Common\Annotations\Annotation\Attribute;
 use Doctrine\Common\Annotations\Annotation\Attributes;
@@ -76,7 +77,7 @@ final class SoftDelete extends BaseModifier
 
         $this->column = $modifier->findColumnName($this->field, $this->column) ?? $this->field;
 
-        $modifier->addDatetimeColumn($this->column, $this->field)
+        $modifier->addDatetimeColumn($this->column, $this->field, SchemaInterface::GENERATED_PHP_UPDATE)
             ->nullable(true);
     }
 }

--- a/src/SoftDelete.php
+++ b/src/SoftDelete.php
@@ -7,7 +7,7 @@ namespace Cycle\ORM\Entity\Behavior;
 use Cycle\ORM\Entity\Behavior\Schema\BaseModifier;
 use Cycle\ORM\Entity\Behavior\Schema\RegistryModifier;
 use Cycle\ORM\Entity\Behavior\Listener\SoftDelete as Listener;
-use Cycle\ORM\SchemaInterface;
+use Cycle\ORM\Schema\GeneratedField;
 use Cycle\Schema\Registry;
 use Doctrine\Common\Annotations\Annotation\Attribute;
 use Doctrine\Common\Annotations\Annotation\Attributes;
@@ -77,7 +77,7 @@ final class SoftDelete extends BaseModifier
 
         $this->column = $modifier->findColumnName($this->field, $this->column) ?? $this->field;
 
-        $modifier->addDatetimeColumn($this->column, $this->field, SchemaInterface::GENERATED_PHP_UPDATE)
+        $modifier->addDatetimeColumn($this->column, $this->field, GeneratedField::BEFORE_UPDATE)
             ->nullable(true);
     }
 }

--- a/src/UpdatedAt.php
+++ b/src/UpdatedAt.php
@@ -7,7 +7,7 @@ namespace Cycle\ORM\Entity\Behavior;
 use Cycle\ORM\Entity\Behavior\Schema\BaseModifier;
 use Cycle\ORM\Entity\Behavior\Schema\RegistryModifier;
 use Cycle\ORM\Entity\Behavior\Listener\UpdatedAt as Listener;
-use Cycle\ORM\SchemaInterface;
+use Cycle\ORM\Schema\GeneratedField;
 use Cycle\Schema\Registry;
 use Doctrine\Common\Annotations\Annotation\Attribute;
 use Doctrine\Common\Annotations\Annotation\Attributes;
@@ -80,7 +80,7 @@ final class UpdatedAt extends BaseModifier
         $modifier->addDatetimeColumn(
             $this->column,
             $this->field,
-            SchemaInterface::GENERATED_PHP_INSERT | SchemaInterface::GENERATED_PHP_UPDATE
+            GeneratedField::BEFORE_INSERT | GeneratedField::BEFORE_UPDATE
         );
     }
 }

--- a/src/UpdatedAt.php
+++ b/src/UpdatedAt.php
@@ -7,6 +7,7 @@ namespace Cycle\ORM\Entity\Behavior;
 use Cycle\ORM\Entity\Behavior\Schema\BaseModifier;
 use Cycle\ORM\Entity\Behavior\Schema\RegistryModifier;
 use Cycle\ORM\Entity\Behavior\Listener\UpdatedAt as Listener;
+use Cycle\ORM\SchemaInterface;
 use Cycle\Schema\Registry;
 use Doctrine\Common\Annotations\Annotation\Attribute;
 use Doctrine\Common\Annotations\Annotation\Attributes;
@@ -76,6 +77,10 @@ final class UpdatedAt extends BaseModifier
 
         $this->column = $modifier->findColumnName($this->field, $this->column) ?? $this->field;
 
-        $modifier->addDatetimeColumn($this->column, $this->field);
+        $modifier->addDatetimeColumn(
+            $this->column,
+            $this->field,
+            SchemaInterface::GENERATED_PHP_INSERT | SchemaInterface::GENERATED_PHP_UPDATE
+        );
     }
 }

--- a/tests/Behavior/Functional/Driver/Common/CreatedAt/CreatedAtTest.php
+++ b/tests/Behavior/Functional/Driver/Common/CreatedAt/CreatedAtTest.php
@@ -6,7 +6,7 @@ namespace Cycle\ORM\Entity\Behavior\Tests\Functional\Driver\Common\CreatedAt;
 
 use Cycle\ORM\Entity\Behavior\Tests\Fixtures\CreatedAt\Post;
 use Cycle\ORM\Entity\Behavior\Tests\Functional\Driver\Common\BaseSchemaTest;
-use Cycle\ORM\SchemaInterface;
+use Cycle\ORM\Schema\GeneratedField;
 use Spiral\Tokenizer\Config\TokenizerConfig;
 use Spiral\Tokenizer\Tokenizer;
 
@@ -29,10 +29,7 @@ abstract class CreatedAtTest extends BaseSchemaTest
         $this->assertTrue($fields->has('createdAt'));
         $this->assertTrue($fields->hasColumn('created_at'));
         $this->assertSame('datetime', $fields->get('createdAt')->getType());
-        $this->assertSame(
-            SchemaInterface::GENERATED_PHP_INSERT,
-            $fields->get('createdAt')->getGenerated()
-        );
+        $this->assertSame(GeneratedField::BEFORE_INSERT, $fields->get('createdAt')->getGenerated());
 
         // No new fields added
         $this->assertSame(3, $fields->count());
@@ -45,9 +42,6 @@ abstract class CreatedAtTest extends BaseSchemaTest
         $this->assertTrue($fields->has('newField'));
         $this->assertTrue($fields->hasColumn('new_field'));
         $this->assertSame('datetime', $fields->get('newField')->getType());
-        $this->assertSame(
-            SchemaInterface::GENERATED_PHP_INSERT,
-            $fields->get('newField')->getGenerated()
-        );
+        $this->assertSame(GeneratedField::BEFORE_INSERT, $fields->get('newField')->getGenerated());
     }
 }

--- a/tests/Behavior/Functional/Driver/Common/CreatedAt/CreatedAtTest.php
+++ b/tests/Behavior/Functional/Driver/Common/CreatedAt/CreatedAtTest.php
@@ -6,6 +6,7 @@ namespace Cycle\ORM\Entity\Behavior\Tests\Functional\Driver\Common\CreatedAt;
 
 use Cycle\ORM\Entity\Behavior\Tests\Fixtures\CreatedAt\Post;
 use Cycle\ORM\Entity\Behavior\Tests\Functional\Driver\Common\BaseSchemaTest;
+use Cycle\ORM\SchemaInterface;
 use Spiral\Tokenizer\Config\TokenizerConfig;
 use Spiral\Tokenizer\Tokenizer;
 
@@ -28,6 +29,10 @@ abstract class CreatedAtTest extends BaseSchemaTest
         $this->assertTrue($fields->has('createdAt'));
         $this->assertTrue($fields->hasColumn('created_at'));
         $this->assertSame('datetime', $fields->get('createdAt')->getType());
+        $this->assertSame(
+            SchemaInterface::GENERATED_PHP_INSERT,
+            $fields->get('createdAt')->getGenerated()
+        );
 
         // No new fields added
         $this->assertSame(3, $fields->count());
@@ -40,5 +45,9 @@ abstract class CreatedAtTest extends BaseSchemaTest
         $this->assertTrue($fields->has('newField'));
         $this->assertTrue($fields->hasColumn('new_field'));
         $this->assertSame('datetime', $fields->get('newField')->getType());
+        $this->assertSame(
+            SchemaInterface::GENERATED_PHP_INSERT,
+            $fields->get('newField')->getGenerated()
+        );
     }
 }

--- a/tests/Behavior/Functional/Driver/Common/OptimisticLock/OptimisticLockTest.php
+++ b/tests/Behavior/Functional/Driver/Common/OptimisticLock/OptimisticLockTest.php
@@ -12,7 +12,7 @@ use Cycle\ORM\Entity\Behavior\Tests\Fixtures\OptimisticLock\Post;
 use Cycle\ORM\Entity\Behavior\Tests\Fixtures\OptimisticLock\Product;
 use Cycle\ORM\Entity\Behavior\Tests\Fixtures\OptimisticLock\WithAllParameters;
 use Cycle\ORM\Entity\Behavior\Tests\Functional\Driver\Common\BaseSchemaTest;
-use Cycle\ORM\SchemaInterface;
+use Cycle\ORM\Schema\GeneratedField;
 use Spiral\Tokenizer\Config\TokenizerConfig;
 use Spiral\Tokenizer\Tokenizer;
 
@@ -36,7 +36,7 @@ abstract class OptimisticLockTest extends BaseSchemaTest
         $this->assertTrue($fields->hasColumn('version'));
         $this->assertSame('integer', $fields->get('version')->getType());
         $this->assertSame(
-            SchemaInterface::GENERATED_PHP_INSERT | SchemaInterface::GENERATED_PHP_UPDATE,
+            GeneratedField::BEFORE_INSERT | GeneratedField::BEFORE_UPDATE,
             $fields->get('version')->getGenerated()
         );
     }
@@ -49,7 +49,7 @@ abstract class OptimisticLockTest extends BaseSchemaTest
         $this->assertTrue($fields->hasColumn('version'));
         $this->assertSame(AbstractColumn::STRING, $fields->get('version')->getType());
         $this->assertSame(
-            SchemaInterface::GENERATED_PHP_INSERT | SchemaInterface::GENERATED_PHP_UPDATE,
+            GeneratedField::BEFORE_INSERT | GeneratedField::BEFORE_UPDATE,
             $fields->get('version')->getGenerated()
         );
     }
@@ -62,7 +62,7 @@ abstract class OptimisticLockTest extends BaseSchemaTest
         $this->assertTrue($fields->hasColumn('version'));
         $this->assertSame('datetime', $fields->get('version')->getType());
         $this->assertSame(
-            SchemaInterface::GENERATED_PHP_INSERT | SchemaInterface::GENERATED_PHP_UPDATE,
+            GeneratedField::BEFORE_INSERT | GeneratedField::BEFORE_UPDATE,
             $fields->get('version')->getGenerated()
         );
     }
@@ -75,7 +75,7 @@ abstract class OptimisticLockTest extends BaseSchemaTest
         $this->assertTrue($fields->hasColumn('revision_field'));
         $this->assertSame('integer', $fields->get('revision')->getType());
         $this->assertSame(
-            SchemaInterface::GENERATED_PHP_INSERT | SchemaInterface::GENERATED_PHP_UPDATE,
+            GeneratedField::BEFORE_INSERT | GeneratedField::BEFORE_UPDATE,
             $fields->get('revision')->getGenerated()
         );
 
@@ -91,7 +91,7 @@ abstract class OptimisticLockTest extends BaseSchemaTest
         $this->assertTrue($fields->hasColumn('revision_field'));
         $this->assertSame('integer', $fields->get('revision')->getType());
         $this->assertSame(
-            SchemaInterface::GENERATED_PHP_INSERT | SchemaInterface::GENERATED_PHP_UPDATE,
+            GeneratedField::BEFORE_INSERT | GeneratedField::BEFORE_UPDATE,
             $fields->get('revision')->getGenerated()
         );
 
@@ -107,7 +107,7 @@ abstract class OptimisticLockTest extends BaseSchemaTest
         $this->assertTrue($fields->hasColumn('version'));
         $this->assertSame('integer', $fields->get('version')->getType());
         $this->assertSame(
-            SchemaInterface::GENERATED_PHP_INSERT | SchemaInterface::GENERATED_PHP_UPDATE,
+            GeneratedField::BEFORE_INSERT | GeneratedField::BEFORE_UPDATE,
             $fields->get('version')->getGenerated()
         );
 

--- a/tests/Behavior/Functional/Driver/Common/OptimisticLock/OptimisticLockTest.php
+++ b/tests/Behavior/Functional/Driver/Common/OptimisticLock/OptimisticLockTest.php
@@ -12,6 +12,7 @@ use Cycle\ORM\Entity\Behavior\Tests\Fixtures\OptimisticLock\Post;
 use Cycle\ORM\Entity\Behavior\Tests\Fixtures\OptimisticLock\Product;
 use Cycle\ORM\Entity\Behavior\Tests\Fixtures\OptimisticLock\WithAllParameters;
 use Cycle\ORM\Entity\Behavior\Tests\Functional\Driver\Common\BaseSchemaTest;
+use Cycle\ORM\SchemaInterface;
 use Spiral\Tokenizer\Config\TokenizerConfig;
 use Spiral\Tokenizer\Tokenizer;
 
@@ -34,6 +35,10 @@ abstract class OptimisticLockTest extends BaseSchemaTest
         $this->assertTrue($fields->has('version'));
         $this->assertTrue($fields->hasColumn('version'));
         $this->assertSame('integer', $fields->get('version')->getType());
+        $this->assertSame(
+            SchemaInterface::GENERATED_PHP_INSERT | SchemaInterface::GENERATED_PHP_UPDATE,
+            $fields->get('version')->getGenerated()
+        );
     }
 
     public function testAddStringColumn(): void
@@ -43,6 +48,10 @@ abstract class OptimisticLockTest extends BaseSchemaTest
         $this->assertTrue($fields->has('version'));
         $this->assertTrue($fields->hasColumn('version'));
         $this->assertSame(AbstractColumn::STRING, $fields->get('version')->getType());
+        $this->assertSame(
+            SchemaInterface::GENERATED_PHP_INSERT | SchemaInterface::GENERATED_PHP_UPDATE,
+            $fields->get('version')->getGenerated()
+        );
     }
 
     public function testAddDatetimeColumn(): void
@@ -52,6 +61,10 @@ abstract class OptimisticLockTest extends BaseSchemaTest
         $this->assertTrue($fields->has('version'));
         $this->assertTrue($fields->hasColumn('version'));
         $this->assertSame('datetime', $fields->get('version')->getType());
+        $this->assertSame(
+            SchemaInterface::GENERATED_PHP_INSERT | SchemaInterface::GENERATED_PHP_UPDATE,
+            $fields->get('version')->getGenerated()
+        );
     }
 
     public function testExistColumn(): void
@@ -61,6 +74,10 @@ abstract class OptimisticLockTest extends BaseSchemaTest
         $this->assertTrue($fields->has('revision'));
         $this->assertTrue($fields->hasColumn('revision_field'));
         $this->assertSame('integer', $fields->get('revision')->getType());
+        $this->assertSame(
+            SchemaInterface::GENERATED_PHP_INSERT | SchemaInterface::GENERATED_PHP_UPDATE,
+            $fields->get('revision')->getGenerated()
+        );
 
         // not added new columns
         $this->assertSame(2, $fields->count());
@@ -73,6 +90,10 @@ abstract class OptimisticLockTest extends BaseSchemaTest
         $this->assertTrue($fields->has('revision'));
         $this->assertTrue($fields->hasColumn('revision_field'));
         $this->assertSame('integer', $fields->get('revision')->getType());
+        $this->assertSame(
+            SchemaInterface::GENERATED_PHP_INSERT | SchemaInterface::GENERATED_PHP_UPDATE,
+            $fields->get('revision')->getGenerated()
+        );
 
         // not added new columns
         $this->assertSame(2, $fields->count());
@@ -85,6 +106,11 @@ abstract class OptimisticLockTest extends BaseSchemaTest
         $this->assertTrue($fields->has('version'));
         $this->assertTrue($fields->hasColumn('version'));
         $this->assertSame('integer', $fields->get('version')->getType());
+        $this->assertSame(
+            SchemaInterface::GENERATED_PHP_INSERT | SchemaInterface::GENERATED_PHP_UPDATE,
+            $fields->get('version')->getGenerated()
+        );
+
         $this->assertSame(2, $fields->count());
     }
 }

--- a/tests/Behavior/Functional/Driver/Common/SoftDelete/SoftDeleteTest.php
+++ b/tests/Behavior/Functional/Driver/Common/SoftDelete/SoftDeleteTest.php
@@ -6,6 +6,7 @@ namespace Cycle\ORM\Entity\Behavior\Tests\Functional\Driver\Common\SoftDelete;
 
 use Cycle\ORM\Entity\Behavior\Tests\Fixtures\SoftDelete\Post;
 use Cycle\ORM\Entity\Behavior\Tests\Functional\Driver\Common\BaseSchemaTest;
+use Cycle\ORM\SchemaInterface;
 use Spiral\Tokenizer\Config\TokenizerConfig;
 use Spiral\Tokenizer\Tokenizer;
 
@@ -28,6 +29,7 @@ abstract class SoftDeleteTest extends BaseSchemaTest
         $this->assertTrue($fields->has('deletedAt'));
         $this->assertTrue($fields->hasColumn('deleted_at'));
         $this->assertSame('datetime', $fields->get('deletedAt')->getType());
+        $this->assertSame(SchemaInterface::GENERATED_PHP_UPDATE, $fields->get('deletedAt')->getGenerated());
 
         // No new fields added
         $this->assertSame(3, $fields->count());
@@ -40,5 +42,6 @@ abstract class SoftDeleteTest extends BaseSchemaTest
         $this->assertTrue($fields->has('newField'));
         $this->assertTrue($fields->hasColumn('new_field'));
         $this->assertSame('datetime', $fields->get('newField')->getType());
+        $this->assertSame(SchemaInterface::GENERATED_PHP_UPDATE, $fields->get('newField')->getGenerated());
     }
 }

--- a/tests/Behavior/Functional/Driver/Common/SoftDelete/SoftDeleteTest.php
+++ b/tests/Behavior/Functional/Driver/Common/SoftDelete/SoftDeleteTest.php
@@ -6,7 +6,7 @@ namespace Cycle\ORM\Entity\Behavior\Tests\Functional\Driver\Common\SoftDelete;
 
 use Cycle\ORM\Entity\Behavior\Tests\Fixtures\SoftDelete\Post;
 use Cycle\ORM\Entity\Behavior\Tests\Functional\Driver\Common\BaseSchemaTest;
-use Cycle\ORM\SchemaInterface;
+use Cycle\ORM\Schema\GeneratedField;
 use Spiral\Tokenizer\Config\TokenizerConfig;
 use Spiral\Tokenizer\Tokenizer;
 
@@ -29,7 +29,7 @@ abstract class SoftDeleteTest extends BaseSchemaTest
         $this->assertTrue($fields->has('deletedAt'));
         $this->assertTrue($fields->hasColumn('deleted_at'));
         $this->assertSame('datetime', $fields->get('deletedAt')->getType());
-        $this->assertSame(SchemaInterface::GENERATED_PHP_UPDATE, $fields->get('deletedAt')->getGenerated());
+        $this->assertSame(GeneratedField::BEFORE_UPDATE, $fields->get('deletedAt')->getGenerated());
 
         // No new fields added
         $this->assertSame(3, $fields->count());
@@ -42,6 +42,6 @@ abstract class SoftDeleteTest extends BaseSchemaTest
         $this->assertTrue($fields->has('newField'));
         $this->assertTrue($fields->hasColumn('new_field'));
         $this->assertSame('datetime', $fields->get('newField')->getType());
-        $this->assertSame(SchemaInterface::GENERATED_PHP_UPDATE, $fields->get('newField')->getGenerated());
+        $this->assertSame(GeneratedField::BEFORE_UPDATE, $fields->get('newField')->getGenerated());
     }
 }

--- a/tests/Behavior/Functional/Driver/Common/UpdatedAt/UpdatedAtTest.php
+++ b/tests/Behavior/Functional/Driver/Common/UpdatedAt/UpdatedAtTest.php
@@ -6,7 +6,7 @@ namespace Cycle\ORM\Entity\Behavior\Tests\Functional\Driver\Common\UpdatedAt;
 
 use Cycle\ORM\Entity\Behavior\Tests\Fixtures\UpdatedAt\Post;
 use Cycle\ORM\Entity\Behavior\Tests\Functional\Driver\Common\BaseSchemaTest;
-use Cycle\ORM\SchemaInterface;
+use Cycle\ORM\Schema\GeneratedField;
 use Spiral\Tokenizer\Config\TokenizerConfig;
 use Spiral\Tokenizer\Tokenizer;
 
@@ -30,7 +30,7 @@ abstract class UpdatedAtTest extends BaseSchemaTest
         $this->assertTrue($fields->hasColumn('updated_at'));
         $this->assertSame('datetime', $fields->get('updatedAt')->getType());
         $this->assertSame(
-            SchemaInterface::GENERATED_PHP_INSERT | SchemaInterface::GENERATED_PHP_UPDATE,
+            GeneratedField::BEFORE_INSERT | GeneratedField::BEFORE_UPDATE,
             $fields->get('updatedAt')->getGenerated()
         );
 
@@ -46,7 +46,7 @@ abstract class UpdatedAtTest extends BaseSchemaTest
         $this->assertTrue($fields->hasColumn('new_field'));
         $this->assertSame('datetime', $fields->get('newField')->getType());
         $this->assertSame(
-            SchemaInterface::GENERATED_PHP_INSERT | SchemaInterface::GENERATED_PHP_UPDATE,
+            GeneratedField::BEFORE_INSERT | GeneratedField::BEFORE_UPDATE,
             $fields->get('newField')->getGenerated()
         );
     }

--- a/tests/Behavior/Functional/Driver/Common/UpdatedAt/UpdatedAtTest.php
+++ b/tests/Behavior/Functional/Driver/Common/UpdatedAt/UpdatedAtTest.php
@@ -6,6 +6,7 @@ namespace Cycle\ORM\Entity\Behavior\Tests\Functional\Driver\Common\UpdatedAt;
 
 use Cycle\ORM\Entity\Behavior\Tests\Fixtures\UpdatedAt\Post;
 use Cycle\ORM\Entity\Behavior\Tests\Functional\Driver\Common\BaseSchemaTest;
+use Cycle\ORM\SchemaInterface;
 use Spiral\Tokenizer\Config\TokenizerConfig;
 use Spiral\Tokenizer\Tokenizer;
 
@@ -28,6 +29,10 @@ abstract class UpdatedAtTest extends BaseSchemaTest
         $this->assertTrue($fields->has('updatedAt'));
         $this->assertTrue($fields->hasColumn('updated_at'));
         $this->assertSame('datetime', $fields->get('updatedAt')->getType());
+        $this->assertSame(
+            SchemaInterface::GENERATED_PHP_INSERT | SchemaInterface::GENERATED_PHP_UPDATE,
+            $fields->get('updatedAt')->getGenerated()
+        );
 
         // No new fields added
         $this->assertSame(3, $fields->count());
@@ -40,5 +45,9 @@ abstract class UpdatedAtTest extends BaseSchemaTest
         $this->assertTrue($fields->has('newField'));
         $this->assertTrue($fields->hasColumn('new_field'));
         $this->assertSame('datetime', $fields->get('newField')->getType());
+        $this->assertSame(
+            SchemaInterface::GENERATED_PHP_INSERT | SchemaInterface::GENERATED_PHP_UPDATE,
+            $fields->get('newField')->getGenerated()
+        );
     }
 }


### PR DESCRIPTION
## What was changed

Added support for `GENERATED_FIELDS` in the schema, which will be in the next version of Cycle ORM

## Checklist

- [x] https://github.com/cycle/orm/pull/462
- [x] https://github.com/cycle/schema-builder/pull/73