### PR TITLE
Remove `@internal` from MapperEvent

### DIFF
--- a/.github/workflows/ci-mssql.yml
+++ b/.github/workflows/ci-mssql.yml
@@ -24,16 +24,16 @@ jobs:
             mssql: 'server:2017-latest'
           - php: '8.0'
             extensions: pdo, pdo_sqlsrv
-            mssql: 'server:2019-latest'
+            mssql: 'server:2019-CU25-ubuntu-20.04'
           - php: '8.1'
             extensions: pdo, pdo_sqlsrv
-            mssql: 'server:2019-latest'
+            mssql: 'server:2019-CU25-ubuntu-20.04'
           - php: '8.2'
             extensions: pdo, pdo_sqlsrv
-            mssql: 'server:2019-latest'
+            mssql: 'server:2019-CU25-ubuntu-20.04'
           - php: '8.3'
             extensions: pdo, pdo_sqlsrv
-            mssql: 'server:2019-latest'
+            mssql: 'server:2019-CU25-ubuntu-20.04'
 
     services:
       mssql:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Setup DB services
         run: |
           cd tests
-          docker-compose up -d
+          docker compose up -d
           cd ..
       - name: Setup PHP ${{ matrix.php-version }}
         uses: shivammathur/setup-php@v2

--- a/src/Event/MapperEvent.php
+++ b/src/Event/MapperEvent.php
@@ -10,8 +10,6 @@ use Cycle\ORM\MapperInterface;
 use Cycle\ORM\Select\SourceInterface;
 
 /**
- * @internal
- *
  * Don't listen to this event
  */
 abstract class MapperEvent

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3"
-
 services:
   sqlserver:
     image: mcr.microsoft.com/mssql/server:2019-latest
@@ -10,8 +8,7 @@ services:
       ACCEPT_EULA: "Y"
 
   mysql_latest:
-    image: mysql:latest
-    restart: always
+    image: mysql:8.0
     command: --default-authentication-plugin=mysql_native_password
     ports:
       - "13306:3306"
@@ -22,7 +19,6 @@ services:
 
   postgres:
     image: postgres:12
-    restart: always
     ports:
       - "15432:5432"
     environment:

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   sqlserver:
-    image: mcr.microsoft.com/mssql/server:2019-latest
+    image: mcr.microsoft.com/mssql/server:2019-CU25-ubuntu-20.04
     ports:
       - "11433:1433"
     environment:


### PR DESCRIPTION
## 🤔 Why?

this class triggers psalm error
```php
use Cycle\ORM\Entity\Behavior\Attribute\Listen;
use Cycle\ORM\Entity\Behavior\Event\Mapper\Command;
use Cycle\ORM\Entity\Behavior\Event\Mapper\QueueCommand;

final class FooListener
{
    #[Listen(Command\OnCreate::class)]
    #[Listen(Command\OnUpdate::class)]
    public function onEvent(QueueCommand $event)
    {
        assert($event->entity instanceof MySuperBarClass);
        // do things
    }
}
```

```
ERROR: InternalProperty
at /home/gam6itko/FooListener.php:x:y
Cycle\ORM\Entity\Behavior\Event\Mapper\QueueCommand::$entity is internal to Cycle but called from FooListener (see https://psalm.dev/176)
        assert($event->entity instanceof MySuperBarClass);

```
