### PR TITLE
Registry modifier big integer

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="6.8.8@1361cd33008feb3ae2b4a93f1860e14e538ec8c2">
+<files psalm-version="6.12.1@e71404b0465be25cf7f8a631b298c01c5ddd864f">
   <file src="src/CreatedAt.php">
     <PropertyNotSetInConstructor>
       <code><![CDATA[CreatedAt]]></code>
@@ -97,6 +97,9 @@
   </file>
   <file src="src/Schema/RegistryModifier.php">
     <ArgumentTypeCoercion>
+      <code><![CDATA[$columnName]]></code>
+      <code><![CDATA[$columnName]]></code>
+      <code><![CDATA[$columnName]]></code>
       <code><![CDATA[$columnName]]></code>
       <code><![CDATA[$columnName]]></code>
       <code><![CDATA[$columnName]]></code>

--- a/src/Schema/RegistryModifier.php
+++ b/src/Schema/RegistryModifier.php
@@ -32,9 +32,14 @@ class RegistryModifier
         'smallInteger',
         'bigInteger',
     ];
+    protected const BIG_INTEGER_TYPES = [
+        'bigint',
+        'bigInteger',
+    ];
     protected const DATETIME_TYPES = ['datetime', 'datetime2'];
     protected const INT_COLUMN = AbstractColumn::INT;
     protected const STRING_COLUMN = AbstractColumn::STRING;
+    protected const BIG_INTEGER_COLUMN = 'bigInteger';
     protected const DATETIME_COLUMN = 'datetime';
     protected const UUID_COLUMN = 'uuid';
 
@@ -56,6 +61,13 @@ class RegistryModifier
         \preg_match(self::DEFINITION, $type, $matches);
 
         return \in_array($matches['type'], self::INTEGER_TYPES, true);
+    }
+
+    public static function isBigIntegerType(string $type): bool
+    {
+        \preg_match(self::DEFINITION, $type, $matches);
+
+        return \in_array($matches['type'], self::BIG_INTEGER_TYPES, true);
     }
 
     public static function isDatetimeType(string $type): bool
@@ -121,6 +133,32 @@ class RegistryModifier
         $this->fields->set($fieldName, $field);
 
         return $this->table->column($columnName)->type(self::INT_COLUMN);
+    }
+
+    public function addBigIntegerColumn(
+        string $columnName,
+        string $fieldName,
+        int|null $generated = null,
+    ): AbstractColumn {
+        if ($this->fields->has($fieldName)) {
+            if (! static::isBigIntegerType($this->fields->get($fieldName)->getType())) {
+                throw new BehaviorCompilationException(\sprintf('Field %s must be of type big integer.', $fieldName));
+            }
+            $this->validateColumnName($fieldName, $columnName);
+            $this->fields->get($fieldName)->setGenerated($generated);
+
+            return $this->table->column($columnName);
+        }
+
+        $field = (new Field())
+            ->setColumn($columnName)
+            ->setType(self::BIG_INTEGER_COLUMN)
+            ->setTypecast('int')
+            ->setGenerated($generated);
+
+        $this->fields->set($fieldName, $field);
+
+        return $this->table->column($columnName)->type(self::BIG_INTEGER_COLUMN);
     }
 
     public function addStringColumn(string $columnName, string $fieldName, int|null $generated = null): AbstractColumn

--- a/tests/Behavior/Functional/Driver/Common/Schema/RegistryModifierTest.php
+++ b/tests/Behavior/Functional/Driver/Common/Schema/RegistryModifierTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Cycle\ORM\Entity\Behavior\Tests\Functional\Driver\Common\Schema;
 
 use Cycle\Database\ColumnInterface;
+use Cycle\ORM\Entity\Behavior\Exception\BehaviorCompilationException;
 use Cycle\ORM\Entity\Behavior\Schema\RegistryModifier;
 use Cycle\ORM\Entity\Behavior\Tests\Fixtures\CustomTypecast;
 use Cycle\ORM\Entity\Behavior\Tests\Functional\Driver\Common\BaseTest;
@@ -57,6 +58,28 @@ abstract class RegistryModifierTest extends BaseTest
         $this->assertSame('version_int', $fields->get('version')->getColumn());
     }
 
+    public function testAddBigIntegerField(): void
+    {
+        $this->modifier->addBigIntegerColumn('snowflake_column', 'snowflake');
+
+        $entity = $this->registry->getEntity(self::ROLE_TEST);
+        $fields = $entity->getFields();
+
+        $this->assertTrue($fields->has('snowflake'));
+        $this->assertSame('bigInteger', $fields->get('snowflake')->getType());
+        $this->assertSame('snowflake_column', $fields->get('snowflake')->getColumn());
+    }
+
+    public function testAddBigIntegerFieldThrowsException(): void
+    {
+        $this->modifier->addIntegerColumn('snowflake_column', 'snowflake');
+
+        $this->expectException(BehaviorCompilationException::class);
+        $this->expectExceptionMessage('Field snowflake must be of type big integer.');
+
+        $this->modifier->addBigIntegerColumn('snowflake_column', 'snowflake');
+    }
+
     public function testAddUuidField(): void
     {
         $this->modifier->addUuidColumn('uuid_column', 'uuid');
@@ -73,15 +96,19 @@ abstract class RegistryModifierTest extends BaseTest
     {
         $this->modifier->addUuidColumn('uuid_column', 'uuid');
         $this->modifier->addIntegerColumn('counter_column', 'counter');
+        $this->modifier->addBigIntegerColumn('snowflake_column', 'snowflake');
         $field1 = $this->registry->getEntity(self::ROLE_TEST)->getFields()->get('uuid');
         $field2 = $this->registry->getEntity(self::ROLE_TEST)->getFields()->get('counter');
+        $field3 = $this->registry->getEntity(self::ROLE_TEST)->getFields()->get('snowflake');
 
         $this->modifier->setTypecast($field1, [Uuid::class, 'fromString']);
         $this->modifier->setTypecast($field2, 'int', CustomTypecast::class);
+        $this->modifier->setTypecast($field3, 'int', CustomTypecast::class);
 
         // field has custom UUID typecast
         $this->assertSame([Uuid::class, 'fromString'], $field1->getTypecast());
         $this->assertSame('int', $field2->getTypecast());
+        $this->assertSame('int', $field3->getTypecast());
 
         // entity has default typecast
         $this->assertSame(

--- a/tests/Behavior/Unit/Schema/RegistryModifierTest.php
+++ b/tests/Behavior/Unit/Schema/RegistryModifierTest.php
@@ -22,6 +22,12 @@ final class RegistryModifierTest extends TestCase
         yield ['integer(4)'];
     }
 
+    public static function bigIntegerDataProvider(): \Traversable
+    {
+        yield ['bigint'];
+        yield ['bigInteger'];
+    }
+
     public static function datetimeDataProvider(): \Traversable
     {
         yield ['datetime'];
@@ -59,6 +65,24 @@ final class RegistryModifierTest extends TestCase
     public function testIsIntegerTypeFalse(mixed $type): void
     {
         $this->assertFalse(RegistryModifier::isIntegerType($type));
+    }
+
+    /**
+     * @dataProvider bigIntegerDataProvider
+     */
+    public function testIsBigIntegerTypeTrue(mixed $type): void
+    {
+        $this->assertTrue(RegistryModifier::isBigIntegerType($type));
+    }
+
+    /**
+     * @dataProvider datetimeDataProvider
+     * @dataProvider stringDataProvider
+     * @dataProvider invalidDataProvider
+     */
+    public function testIsBigIntegerTypeFalse(mixed $type): void
+    {
+        $this->assertFalse(RegistryModifier::isBigIntegerType($type));
     }
 
     /**


### PR DESCRIPTION
This is a chess move, thinking ahead when needing to support Snowflake ID's which are 64 bit integers primarily stored in a `bigInteger` column. In preparation for https://github.com/cycle/entity-behavior-identifier see :tickets:  https://github.com/cycle/entity-behavior-uuid/issues/13

## 🔍 What was changed

Not allot, just added methods for determining whether a type matches `bigInteger` and  creating a `bigInteger` type column.

## 📝 Checklist

- How was this tested:
  - [x] Unit tests added
