### PR TITLE
Registry modifier ULID

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,138 +1,137 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <files psalm-version="6.12.1@e71404b0465be25cf7f8a631b298c01c5ddd864f">
-  <file src="src/CreatedAt.php">
-    <PropertyNotSetInConstructor>
-      <code><![CDATA[CreatedAt]]></code>
-    </PropertyNotSetInConstructor>
-  </file>
-  <file src="src/Dispatcher/ListenerProvider.php">
-    <DocblockTypeContradiction>
-      <code><![CDATA[!\is_array($event)]]></code>
-    </DocblockTypeContradiction>
-    <MixedArgument>
-      <code><![CDATA[$arguments]]></code>
-      <code><![CDATA[$definition]]></code>
-      <code><![CDATA[$definition[self::DEFINITION_CLASS]]]></code>
-      <code><![CDATA[$role]]></code>
-    </MixedArgument>
-    <MixedArrayAccess>
-      <code><![CDATA[$definition[self::DEFINITION_CLASS]]]></code>
-    </MixedArrayAccess>
-    <MixedAssignment>
-      <code><![CDATA[$arguments]]></code>
-      <code><![CDATA[$role]]></code>
-    </MixedAssignment>
-    <RedundantConditionGivenDocblockType>
-      <code><![CDATA[\assert($listen instanceof Listen)]]></code>
-    </RedundantConditionGivenDocblockType>
-  </file>
-  <file src="src/Event/Mapper/Command/OnCreate.php">
-    <PropertyNotSetInConstructor>
-      <code><![CDATA[OnCreate]]></code>
-    </PropertyNotSetInConstructor>
-  </file>
-  <file src="src/Event/Mapper/Command/OnDelete.php">
-    <PropertyNotSetInConstructor>
-      <code><![CDATA[OnDelete]]></code>
-    </PropertyNotSetInConstructor>
-  </file>
-  <file src="src/Event/Mapper/Command/OnUpdate.php">
-    <PropertyNotSetInConstructor>
-      <code><![CDATA[OnUpdate]]></code>
-    </PropertyNotSetInConstructor>
-  </file>
-  <file src="src/EventDrivenCommandGenerator.php">
-    <MixedReturnStatement>
-      <code><![CDATA[$event->command]]></code>
-      <code><![CDATA[$event->command]]></code>
-      <code><![CDATA[$event->command]]></code>
-    </MixedReturnStatement>
-    <PropertyNotSetInConstructor>
-      <code><![CDATA[$timestamp]]></code>
-    </PropertyNotSetInConstructor>
-  </file>
-  <file src="src/EventListener.php">
-    <MixedArrayAssignment>
-      <code><![CDATA[$schema[SchemaInterface::LISTENERS][]]]></code>
-    </MixedArrayAssignment>
-    <PropertyNotSetInConstructor>
-      <code><![CDATA[$role]]></code>
-    </PropertyNotSetInConstructor>
-  </file>
-  <file src="src/Exception/OptimisticLock/ChangedVersionException.php">
-    <ClassMustBeFinal>
-      <code><![CDATA[ChangedVersionException]]></code>
-    </ClassMustBeFinal>
-    <MixedArgument>
-      <code><![CDATA[$new]]></code>
-      <code><![CDATA[$old]]></code>
-    </MixedArgument>
-  </file>
-  <file src="src/Exception/OptimisticLock/RecordIsLockedException.php">
-    <ClassMustBeFinal>
-      <code><![CDATA[RecordIsLockedException]]></code>
-    </ClassMustBeFinal>
-  </file>
-  <file src="src/Hook.php">
-    <PropertyNotSetInConstructor>
-      <code><![CDATA[Hook]]></code>
-    </PropertyNotSetInConstructor>
-  </file>
-  <file src="src/Listener/OptimisticLock.php">
-    <MixedAssignment>
-      <code><![CDATA[$nodeValue]]></code>
-      <code><![CDATA[$stateValue]]></code>
-    </MixedAssignment>
-  </file>
-  <file src="src/OptimisticLock.php">
-    <PropertyNotSetInConstructor>
-      <code><![CDATA[OptimisticLock]]></code>
-    </PropertyNotSetInConstructor>
-  </file>
-  <file src="src/Schema/BaseModifier.php">
-    <MixedArrayAssignment>
-      <code><![CDATA[$schema[SchemaInterface::LISTENERS][]]]></code>
-      <code><![CDATA[$schema[SchemaInterface::LISTENERS][]]]></code>
-    </MixedArrayAssignment>
-  </file>
-  <file src="src/Schema/RegistryModifier.php">
-    <ArgumentTypeCoercion>
-      <code><![CDATA[$columnName]]></code>
-      <code><![CDATA[$columnName]]></code>
-      <code><![CDATA[$columnName]]></code>
-      <code><![CDATA[$columnName]]></code>
-      <code><![CDATA[$columnName]]></code>
-      <code><![CDATA[$columnName]]></code>
-      <code><![CDATA[$columnName]]></code>
-      <code><![CDATA[$columnName]]></code>
-      <code><![CDATA[$columnName]]></code>
-      <code><![CDATA[$columnName]]></code>
-      <code><![CDATA[$columnName]]></code>
-      <code><![CDATA[$columnName]]></code>
-      <code><![CDATA[$columnName]]></code>
-      <code><![CDATA[$columnName]]></code>
-      <code><![CDATA[$columnName]]></code>
-      <code><![CDATA[$columnName]]></code>
-      <code><![CDATA[$columnName]]></code>
-      <code><![CDATA[$columnName]]></code>
-      <code><![CDATA[$columnName]]></code>
-      <code><![CDATA[$rule]]></code>
-    </ArgumentTypeCoercion>
-    <ClassMustBeFinal>
-      <code><![CDATA[RegistryModifier]]></code>
-    </ClassMustBeFinal>
-    <MixedAssignment>
-      <code><![CDATA[$defaultHandlers]]></code>
-    </MixedAssignment>
-  </file>
-  <file src="src/SoftDelete.php">
-    <PropertyNotSetInConstructor>
-      <code><![CDATA[SoftDelete]]></code>
-    </PropertyNotSetInConstructor>
-  </file>
-  <file src="src/UpdatedAt.php">
-    <PropertyNotSetInConstructor>
-      <code><![CDATA[UpdatedAt]]></code>
-    </PropertyNotSetInConstructor>
-  </file>
+    <file src="src/CreatedAt.php">
+        <PropertyNotSetInConstructor>
+            <code><![CDATA[CreatedAt]]></code>
+        </PropertyNotSetInConstructor>
+    </file>
+    <file src="src/Dispatcher/ListenerProvider.php">
+        <DocblockTypeContradiction>
+            <code><![CDATA[!\is_array($event)]]></code>
+        </DocblockTypeContradiction>
+        <MixedArgument>
+            <code><![CDATA[$arguments]]></code>
+            <code><![CDATA[$definition]]></code>
+            <code><![CDATA[$definition[self::DEFINITION_CLASS]]]></code>
+            <code><![CDATA[$role]]></code>
+        </MixedArgument>
+        <MixedArrayAccess>
+            <code><![CDATA[$definition[self::DEFINITION_CLASS]]]></code>
+        </MixedArrayAccess>
+        <MixedAssignment>
+            <code><![CDATA[$arguments]]></code>
+            <code><![CDATA[$role]]></code>
+        </MixedAssignment>
+        <RedundantConditionGivenDocblockType>
+            <code><![CDATA[\assert($listen instanceof Listen)]]></code>
+        </RedundantConditionGivenDocblockType>
+    </file>
+    <file src="src/Event/Mapper/Command/OnCreate.php">
+        <PropertyNotSetInConstructor>
+            <code><![CDATA[OnCreate]]></code>
+        </PropertyNotSetInConstructor>
+    </file>
+    <file src="src/Event/Mapper/Command/OnDelete.php">
+        <PropertyNotSetInConstructor>
+            <code><![CDATA[OnDelete]]></code>
+        </PropertyNotSetInConstructor>
+    </file>
+    <file src="src/Event/Mapper/Command/OnUpdate.php">
+        <PropertyNotSetInConstructor>
+            <code><![CDATA[OnUpdate]]></code>
+        </PropertyNotSetInConstructor>
+    </file>
+    <file src="src/EventDrivenCommandGenerator.php">
+        <MixedReturnStatement>
+            <code><![CDATA[$event->command]]></code>
+            <code><![CDATA[$event->command]]></code>
+            <code><![CDATA[$event->command]]></code>
+        </MixedReturnStatement>
+        <PropertyNotSetInConstructor>
+            <code><![CDATA[$timestamp]]></code>
+        </PropertyNotSetInConstructor>
+    </file>
+    <file src="src/EventListener.php">
+        <MixedArrayAssignment>
+            <code><![CDATA[$schema[SchemaInterface::LISTENERS][]]]></code>
+        </MixedArrayAssignment>
+        <PropertyNotSetInConstructor>
+            <code><![CDATA[$role]]></code>
+        </PropertyNotSetInConstructor>
+    </file>
+    <file src="src/Exception/OptimisticLock/ChangedVersionException.php">
+        <ClassMustBeFinal>
+            <code><![CDATA[ChangedVersionException]]></code>
+        </ClassMustBeFinal>
+        <MixedArgument>
+            <code><![CDATA[$new]]></code>
+            <code><![CDATA[$old]]></code>
+        </MixedArgument>
+    </file>
+    <file src="src/Exception/OptimisticLock/RecordIsLockedException.php">
+        <ClassMustBeFinal>
+            <code><![CDATA[RecordIsLockedException]]></code>
+        </ClassMustBeFinal>
+    </file>
+    <file src="src/Hook.php">
+        <PropertyNotSetInConstructor>
+            <code><![CDATA[Hook]]></code>
+        </PropertyNotSetInConstructor>
+    </file>
+    <file src="src/Listener/OptimisticLock.php">
+        <MixedAssignment>
+            <code><![CDATA[$nodeValue]]></code>
+            <code><![CDATA[$stateValue]]></code>
+        </MixedAssignment>
+    </file>
+    <file src="src/OptimisticLock.php">
+        <PropertyNotSetInConstructor>
+            <code><![CDATA[OptimisticLock]]></code>
+        </PropertyNotSetInConstructor>
+    </file>
+    <file src="src/Schema/BaseModifier.php">
+        <MixedArrayAssignment>
+            <code><![CDATA[$schema[SchemaInterface::LISTENERS][]]]></code>
+            <code><![CDATA[$schema[SchemaInterface::LISTENERS][]]]></code>
+        </MixedArrayAssignment>
+    </file>
+    <file src="src/Schema/RegistryModifier.php">
+        <ArgumentTypeCoercion>
+            <code><![CDATA[$columnName]]></code>
+            <code><![CDATA[$columnName]]></code>
+            <code><![CDATA[$columnName]]></code>
+            <code><![CDATA[$columnName]]></code>
+            <code><![CDATA[$columnName]]></code>
+            <code><![CDATA[$columnName]]></code>
+            <code><![CDATA[$columnName]]></code>
+            <code><![CDATA[$columnName]]></code>
+            <code><![CDATA[$columnName]]></code>
+            <code><![CDATA[$columnName]]></code>
+            <code><![CDATA[$columnName]]></code>
+            <code><![CDATA[$columnName]]></code>
+            <code><![CDATA[$columnName]]></code>
+            <code><![CDATA[$columnName]]></code>
+            <code><![CDATA[$columnName]]></code>
+            <code><![CDATA[$columnName]]></code>
+            <code><![CDATA[$columnName]]></code>
+            <code><![CDATA[$columnName]]></code>
+            <code><![CDATA[$rule]]></code>
+        </ArgumentTypeCoercion>
+        <ClassMustBeFinal>
+            <code><![CDATA[RegistryModifier]]></code>
+        </ClassMustBeFinal>
+        <MixedAssignment>
+            <code><![CDATA[$defaultHandlers]]></code>
+        </MixedAssignment>
+    </file>
+    <file src="src/SoftDelete.php">
+        <PropertyNotSetInConstructor>
+            <code><![CDATA[SoftDelete]]></code>
+        </PropertyNotSetInConstructor>
+    </file>
+    <file src="src/UpdatedAt.php">
+        <PropertyNotSetInConstructor>
+            <code><![CDATA[UpdatedAt]]></code>
+        </PropertyNotSetInConstructor>
+    </file>
 </files>

--- a/src/Schema/RegistryModifier.php
+++ b/src/Schema/RegistryModifier.php
@@ -290,6 +290,10 @@ class RegistryModifier
 
     /**
      * @deprecated since v1.2
+     *
+     * @param non-empty-string $type
+     * @param non-empty-string $fieldName
+     * @param non-empty-string $columnName
      */
     protected function isType(string $type, string $fieldName, string $columnName): bool
     {

--- a/src/Schema/RegistryModifier.php
+++ b/src/Schema/RegistryModifier.php
@@ -41,6 +41,7 @@ class RegistryModifier
     protected const STRING_COLUMN = AbstractColumn::STRING;
     protected const BIG_INTEGER_COLUMN = 'bigInteger';
     protected const DATETIME_COLUMN = 'datetime';
+    protected const ULID_COLUMN = 'ulid';
     protected const UUID_COLUMN = 'uuid';
 
     protected FieldMap $fields;
@@ -84,11 +85,18 @@ class RegistryModifier
         return $matches['type'] === 'string';
     }
 
+    public static function isUlidType(string $type): bool
+    {
+        \preg_match(self::DEFINITION, $type, $matches);
+
+        return $matches['type'] === self::ULID_COLUMN;
+    }
+
     public static function isUuidType(string $type): bool
     {
         \preg_match(self::DEFINITION, $type, $matches);
 
-        return $matches['type'] === 'uuid';
+        return $matches['type'] === self::UUID_COLUMN;
     }
 
     public function addDatetimeColumn(string $columnName, string $fieldName, int|null $generated = null): AbstractColumn
@@ -182,11 +190,13 @@ class RegistryModifier
     /**
      * @throws BehaviorCompilationException
      */
-    public function addUuidColumn(string $columnName, string $fieldName, int|null $generated = null): AbstractColumn
+    public function addUlidColumn(string $columnName, string $fieldName, int|null $generated = null): AbstractColumn
     {
         if ($this->fields->has($fieldName)) {
-            if (!static::isUuidType($this->fields->get($fieldName)->getType())) {
-                throw new BehaviorCompilationException(\sprintf('Field %s must be of type uuid.', $fieldName));
+            if (!static::isUlidType($this->fields->get($fieldName)->getType())) {
+                throw new BehaviorCompilationException(
+                    \sprintf('Field %s must be of type %s.', $fieldName, self::ULID_COLUMN),
+                );
             }
             $this->validateColumnName($fieldName, $columnName);
             $this->fields->get($fieldName)->setGenerated($generated);
@@ -194,7 +204,30 @@ class RegistryModifier
             return $this->table->column($columnName);
         }
 
-        $field = (new Field())->setColumn($columnName)->setType('uuid')->setGenerated($generated);
+        $field = (new Field())->setColumn($columnName)->setType(self::ULID_COLUMN)->setGenerated($generated);
+        $this->fields->set($fieldName, $field);
+
+        return $this->table->column($columnName)->type(self::ULID_COLUMN);
+    }
+
+    /**
+     * @throws BehaviorCompilationException
+     */
+    public function addUuidColumn(string $columnName, string $fieldName, int|null $generated = null): AbstractColumn
+    {
+        if ($this->fields->has($fieldName)) {
+            if (!static::isUuidType($this->fields->get($fieldName)->getType())) {
+                throw new BehaviorCompilationException(
+                    \sprintf('Field %s must be of type %s.', $fieldName, self::UUID_COLUMN),
+                );
+            }
+            $this->validateColumnName($fieldName, $columnName);
+            $this->fields->get($fieldName)->setGenerated($generated);
+
+            return $this->table->column($columnName);
+        }
+
+        $field = (new Field())->setColumn($columnName)->setType(self::UUID_COLUMN)->setGenerated($generated);
         $this->fields->set($fieldName, $field);
 
         return $this->table->column($columnName)->type(self::UUID_COLUMN);

--- a/tests/Behavior/Functional/Driver/Common/Schema/RegistryModifierTest.php
+++ b/tests/Behavior/Functional/Driver/Common/Schema/RegistryModifierTest.php
@@ -80,6 +80,28 @@ abstract class RegistryModifierTest extends BaseTest
         $this->modifier->addBigIntegerColumn('snowflake_column', 'snowflake');
     }
 
+    public function testAddUlidField(): void
+    {
+        $this->modifier->addUlidColumn('ulid_column', 'ulid');
+
+        $entity = $this->registry->getEntity(self::ROLE_TEST);
+        $fields = $entity->getFields();
+
+        $this->assertTrue($fields->has('ulid'));
+        $this->assertSame('ulid', $fields->get('ulid')->getType());
+        $this->assertSame('ulid_column', $fields->get('ulid')->getColumn());
+    }
+
+    public function testAddUlidFieldThrowsException(): void
+    {
+        $this->modifier->addIntegerColumn('ulid_column', 'ulid');
+
+        $this->expectException(BehaviorCompilationException::class);
+        $this->expectExceptionMessage('Field ulid must be of type ulid.');
+
+        $this->modifier->addUlidColumn('ulid_column', 'ulid');
+    }
+
     public function testAddUuidField(): void
     {
         $this->modifier->addUuidColumn('uuid_column', 'uuid');
@@ -90,6 +112,16 @@ abstract class RegistryModifierTest extends BaseTest
         $this->assertTrue($fields->has('uuid'));
         $this->assertSame('uuid', $fields->get('uuid')->getType());
         $this->assertSame('uuid_column', $fields->get('uuid')->getColumn());
+    }
+
+    public function testAddUuidFieldThrowsException(): void
+    {
+        $this->modifier->addIntegerColumn('uuid_column', 'uuid');
+
+        $this->expectException(BehaviorCompilationException::class);
+        $this->expectExceptionMessage('Field uuid must be of type uuid.');
+
+        $this->modifier->addUuidColumn('uuid_column', 'uuid');
     }
 
     public function testAddTypecast(): void

--- a/tests/Behavior/Unit/Schema/RegistryModifierTest.php
+++ b/tests/Behavior/Unit/Schema/RegistryModifierTest.php
@@ -121,6 +121,22 @@ final class RegistryModifierTest extends TestCase
         $this->assertFalse(RegistryModifier::isStringType($type));
     }
 
+    public function testIsUlidTypeTrue(): void
+    {
+        $this->assertTrue(RegistryModifier::isUlidType('ulid'));
+    }
+
+    /**
+     * @dataProvider integerDataProvider
+     * @dataProvider datetimeDataProvider
+     * @dataProvider invalidDataProvider
+     * @dataProvider stringDataProvider
+     */
+    public function testIsUlidTypeFalse(mixed $type): void
+    {
+        $this->assertFalse(RegistryModifier::isUlidType($type));
+    }
+
     public function testIsUuidTypeTrue(): void
     {
         $this->assertTrue(RegistryModifier::isUuidType('uuid'));


### PR DESCRIPTION
This is a chess move, thinking ahead when needing to support ULID's, in preparation for https://github.com/cycle/entity-behavior-identifier see :tickets:  https://github.com/cycle/entity-behavior-uuid/issues/13

Needing this and https://github.com/cycle/database/pull/233 merged in order finish implementing ULID's within https://github.com/cycle/entity-behavior-identifier

## 🔍 What was changed

Not allot, just added methods for determining whether a type matches `ulid` and  creating a `ulid` type column.

## 📝 Checklist

- How was this tested:
  - [x] Unit tests added
- [ ] Wait release https://github.com/cycle/database/pull/233
